### PR TITLE
feat: add HTTP transport and standalone CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,53 @@ Add to `.claude/settings.local.json` in your project, or to your global Claude C
 
 <div align="center">
 
+## HTTP Transport
+
+For clients or editors that connect over HTTP instead of stdio, start the server in HTTP mode. It uses the MCP Streamable HTTP transport with per-session isolation.
+
+| Flag | Description |
+| --- | --- |
+| `--http` | Start with the Streamable HTTP transport instead of stdio |
+| `--port <number>` | Port to listen on (default: `3000`) — also implies `--http` |
+| `--host <address>` | Host to bind to (default: `127.0.0.1`) |
+
+</div>
+
+```bash
+minecraft-dev-mcp --http --port 3000
+```
+
+The MCP endpoint is `http://<host>:<port>/mcp` (POST to call, GET for the SSE stream, DELETE to end a session). Each client gets its own session, so multiple clients can connect concurrently.
+
+> **Security:** the default host `127.0.0.1` enables the SDK's DNS-rebinding protection automatically. Binding to a non-loopback host (e.g. `--host 0.0.0.0`) disables that protection — only do so on a trusted network, ideally behind a reverse proxy or auth.
+
+---
+
+<div align="center">
+
+## CLI
+
+A standalone CLI (`minecraft-dev-cli`) invokes the same tools directly — no MCP client required — for scripts, skills, and automation. Arguments are **flags-only** (`--key value` or `--key=value`) to avoid the JSON-quoting issues positional JSON arguments cause in PowerShell and other shells.
+
+</div>
+
+```bash
+# List every tool with its parameters
+minecraft-dev-cli list-tools
+
+# Invoke a tool with flags
+minecraft-dev-cli get_minecraft_source --version 1.21.10 --className net.minecraft.world.entity.Entity --mapping yarn
+
+# Boolean / numeric / JSON values are coerced automatically
+minecraft-dev-cli analyze_mod_jar --jarPath C:\mods\example.jar --includeAllClasses true
+```
+
+Output is always JSON: `{ "success": true, "tool": "...", "result": ... }` on success, or `{ "success": false, "tool": "...", "error": "..." }` with exit code `1` on failure. Run `minecraft-dev-cli help` for full usage.
+
+---
+
+<div align="center">
+
 ## Features
 
 | Feature | Description |

--- a/__tests__/helpers/cli-runner.ts
+++ b/__tests__/helpers/cli-runner.ts
@@ -1,0 +1,69 @@
+import { type SpawnOptions, spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+export interface CliResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+/**
+ * Resolve how to launch the CLI. Prefers the built dist entry when present
+ * (and when MCP_E2E_USE_DIST=1), otherwise falls back to running the source
+ * through tsx so tests work without a prior build.
+ */
+function getCliCommand(): { command: string; baseArgs: string[] } {
+  const projectRoot = process.cwd();
+  const distEntry = join(projectRoot, 'dist', 'cli.js');
+  const useDist = process.env.MCP_E2E_USE_DIST === '1';
+
+  if (useDist && existsSync(distEntry)) {
+    return { command: process.execPath, baseArgs: [distEntry] };
+  }
+
+  const tsxCli = join(projectRoot, 'node_modules', 'tsx', 'dist', 'cli.mjs');
+  const srcEntry = join(projectRoot, 'src', 'cli.ts');
+  return { command: process.execPath, baseArgs: [tsxCli, srcEntry] };
+}
+
+/**
+ * Run the minecraft-dev CLI with the given args and capture its output.
+ */
+export function runCli(args: string[], timeoutMs = 60000): Promise<CliResult> {
+  const { command, baseArgs } = getCliCommand();
+
+  const options: SpawnOptions = {
+    cwd: process.cwd(),
+    env: { ...process.env, LOG_LEVEL: 'ERROR' },
+  };
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, [...baseArgs, ...args], options);
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout?.on('data', (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr?.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      reject(new Error(`CLI timed out after ${timeoutMs}ms (args: ${args.join(' ')})`));
+    }, timeoutMs);
+
+    child.on('error', (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      resolve({ exitCode: code ?? -1, stdout, stderr });
+    });
+  });
+}

--- a/__tests__/helpers/mcp-http.ts
+++ b/__tests__/helpers/mcp-http.ts
@@ -59,7 +59,10 @@ export async function startHttpMcpServer(host = '127.0.0.1'): Promise<HttpMcpSer
     {
       cwd: process.cwd(),
       env: { ...process.env, LOG_LEVEL: 'ERROR' },
-      stdio: ['ignore', 'pipe', 'pipe'],
+      // Logger writes to a file; we only consume stderr for early-exit
+      // diagnostics. Ignore stdout so a full pipe buffer can never block the
+      // child process.
+      stdio: ['ignore', 'ignore', 'pipe'],
     },
   );
 

--- a/__tests__/helpers/mcp-http.ts
+++ b/__tests__/helpers/mcp-http.ts
@@ -1,0 +1,129 @@
+import { type ChildProcess, spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { createServer } from 'node:net';
+import { join } from 'node:path';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+
+export interface HttpMcpServer {
+  /** Base URL of the MCP endpoint, e.g. http://127.0.0.1:3000/mcp */
+  url: string;
+  host: string;
+  port: number;
+  /** Open a new MCP client session against this server. */
+  connectClient: (name: string) => Promise<{ client: Client; close: () => Promise<void> }>;
+  /** Stop the server process. */
+  close: () => Promise<void>;
+}
+
+function getServerCommand(): { command: string; baseArgs: string[] } {
+  const projectRoot = process.cwd();
+  const distEntry = join(projectRoot, 'dist', 'index.js');
+  const useDist = process.env.MCP_E2E_USE_DIST === '1';
+
+  if (useDist && existsSync(distEntry)) {
+    return { command: process.execPath, baseArgs: [distEntry] };
+  }
+
+  const tsxCli = join(projectRoot, 'node_modules', 'tsx', 'dist', 'cli.mjs');
+  const srcEntry = join(projectRoot, 'src', 'index.ts');
+  return { command: process.execPath, baseArgs: [tsxCli, srcEntry] };
+}
+
+/** Grab an ephemeral free port from the OS. */
+function getFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.on('error', reject);
+    srv.listen(0, '127.0.0.1', () => {
+      const addr = srv.address();
+      const port = typeof addr === 'object' && addr ? addr.port : 0;
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Spawn the MCP server in HTTP mode on a free port and wait until it accepts
+ * MCP client connections.
+ */
+export async function startHttpMcpServer(host = '127.0.0.1'): Promise<HttpMcpServer> {
+  const port = await getFreePort();
+  const { command, baseArgs } = getServerCommand();
+
+  const child: ChildProcess = spawn(
+    command,
+    [...baseArgs, '--http', '--port', String(port), '--host', host],
+    {
+      cwd: process.cwd(),
+      env: { ...process.env, LOG_LEVEL: 'ERROR' },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    },
+  );
+
+  const stderrChunks: string[] = [];
+  child.stderr?.on('data', (c) => stderrChunks.push(c.toString()));
+
+  let exited = false;
+  child.on('exit', () => {
+    exited = true;
+  });
+
+  const url = `http://${host}:${port}/mcp`;
+
+  const connectClient = async (name: string) => {
+    const transport = new StreamableHTTPClientTransport(new URL(url));
+    const client = new Client({ name, version: '1.0.0' });
+    await client.connect(transport);
+    return {
+      client,
+      close: async () => {
+        await client.close();
+      },
+    };
+  };
+
+  // Wait until the server is accepting MCP connections.
+  const deadline = Date.now() + 30000;
+  let lastError: unknown;
+  while (Date.now() < deadline) {
+    if (exited) {
+      throw new Error(`HTTP server exited early. stderr:\n${stderrChunks.join('')}`);
+    }
+    try {
+      const probe = await connectClient('readiness-probe');
+      await probe.close();
+      lastError = undefined;
+      break;
+    } catch (error) {
+      lastError = error;
+      await sleep(250);
+    }
+  }
+
+  if (lastError) {
+    child.kill('SIGKILL');
+    throw new Error(
+      `HTTP server did not become ready: ${
+        lastError instanceof Error ? lastError.message : String(lastError)
+      }\nstderr:\n${stderrChunks.join('')}`,
+    );
+  }
+
+  return {
+    url,
+    host,
+    port,
+    connectClient,
+    close: async () => {
+      if (!exited) {
+        child.kill('SIGTERM');
+        // Give it a moment, then force-kill if still alive.
+        await sleep(300);
+        if (!exited) child.kill('SIGKILL');
+      }
+    },
+  };
+}

--- a/__tests__/manual/mcp/http-server-smoke.test.ts
+++ b/__tests__/manual/mcp/http-server-smoke.test.ts
@@ -1,0 +1,94 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { type HttpMcpServer, startHttpMcpServer } from '../../helpers/mcp-http.js';
+
+/**
+ * True MCP HTTP transport E2E tests.
+ *
+ * Starts the actual server in HTTP mode (`--http`) on an ephemeral port and
+ * drives it through the MCP Streamable HTTP client transport. Verifies tool
+ * listing, resource reads, per-session isolation, and the bad-request path.
+ *
+ * Lives in the manual suite (alongside the stdio smoke) because it spawns the
+ * real Java-gated server and reads the live Mojang version manifest.
+ */
+describe('MCP HTTP Server Smoke', () => {
+  let server: HttpMcpServer;
+
+  beforeAll(async () => {
+    server = await startHttpMcpServer();
+  }, 60000);
+
+  afterAll(async () => {
+    if (server) {
+      await server.close();
+    }
+  }, 30000);
+
+  it('lists tools over the HTTP transport', async () => {
+    const { client, close } = await server.connectClient('http-smoke-tools');
+    try {
+      const result = await client.listTools();
+      expect(result.tools.length).toBe(20);
+      const names = result.tools.map((t) => t.name);
+      expect(names).toContain('get_minecraft_source');
+      expect(names).toContain('decompile_minecraft_version');
+      expect(names).toContain('get_registry_data');
+    } finally {
+      await close();
+    }
+  }, 30000);
+
+  it('reads the versions resource over the HTTP transport', async () => {
+    const { client, close } = await server.connectClient('http-smoke-resource');
+    try {
+      const result = await client.readResource({ uri: 'minecraft://versions/list' });
+      expect(result.contents.length).toBe(1);
+      const first = result.contents[0];
+      expect(typeof first.text).toBe('string');
+
+      const data = JSON.parse(first.text ?? '{}');
+      expect(Array.isArray(data.available)).toBe(true);
+      expect(data.total_available).toBeGreaterThan(0);
+    } finally {
+      await close();
+    }
+  }, 30000);
+
+  it('isolates concurrent client sessions', async () => {
+    const a = await server.connectClient('http-smoke-session-a');
+    const b = await server.connectClient('http-smoke-session-b');
+    try {
+      // Both independent sessions must work against the same server process.
+      const [ra, rb] = await Promise.all([a.client.listTools(), b.client.listTools()]);
+      expect(ra.tools.length).toBe(20);
+      expect(rb.tools.length).toBe(20);
+    } finally {
+      await Promise.all([a.close(), b.close()]);
+    }
+  }, 30000);
+
+  it('rejects a POST without a session id that is not an initialize request', async () => {
+    const res = await fetch(server.url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream',
+      },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error?.code).toBe(-32000);
+    expect(body.error?.message).toMatch(/no valid session id/i);
+  }, 15000);
+
+  it('rejects a GET without a valid session id', async () => {
+    const res = await fetch(server.url, {
+      method: 'GET',
+      headers: { Accept: 'text/event-stream' },
+    });
+
+    expect(res.status).toBe(400);
+  }, 15000);
+});

--- a/__tests__/manual/mcp/http-server-smoke.test.ts
+++ b/__tests__/manual/mcp/http-server-smoke.test.ts
@@ -67,6 +67,53 @@ describe('MCP HTTP Server Smoke', () => {
     }
   }, 30000);
 
+  it('accepts the session id via ?sessionId= query param (browser EventSource fallback)', async () => {
+    const accept = 'application/json, text/event-stream';
+
+    // 1. Initialize to obtain a session id (returned in the response header).
+    const initRes = await fetch(server.url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Accept: accept },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2024-11-05',
+          capabilities: {},
+          clientInfo: { name: 'query-smoke', version: '0.0.0' },
+        },
+      }),
+    });
+    expect(initRes.status).toBe(200);
+    const sid = initRes.headers.get('mcp-session-id');
+    expect(sid).toBeTruthy();
+    await initRes.text();
+
+    // 2. Complete the handshake using ONLY the query param (no header).
+    const notifyRes = await fetch(`${server.url}?sessionId=${sid}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Accept: accept },
+      body: JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }),
+    });
+    expect(notifyRes.status).toBeLessThan(300);
+    await notifyRes.text();
+
+    // 3. tools/list using ONLY the query param must be accepted.
+    const listRes = await fetch(`${server.url}?sessionId=${sid}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Accept: accept },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list' }),
+    });
+    expect(listRes.status).toBe(200);
+
+    const text = await listRes.text();
+    const dataLine = text.split('\n').find((line) => line.startsWith('data:'));
+    expect(dataLine).toBeTruthy();
+    const payload = JSON.parse((dataLine as string).slice('data:'.length).trim());
+    expect(payload.result.tools.length).toBe(20);
+  }, 30000);
+
   it('rejects a POST without a session id that is not an initialize request', async () => {
     const res = await fetch(server.url, {
       method: 'POST',

--- a/__tests__/tools/cli-args.test.ts
+++ b/__tests__/tools/cli-args.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { parseArgs, parseFlagValue } from '../../src/cli.js';
+import { tools } from '../../src/server/tools.js';
+
+// A stable, known tool name to drive parseArgs tests.
+const TOOL = tools[0].name;
+
+describe('parseFlagValue', () => {
+  it('coerces booleans', () => {
+    expect(parseFlagValue('true')).toBe(true);
+    expect(parseFlagValue('false')).toBe(false);
+  });
+
+  it('coerces JSON literals', () => {
+    expect(parseFlagValue('42')).toBe(42);
+    expect(parseFlagValue('[1,2,3]')).toEqual([1, 2, 3]);
+    expect(parseFlagValue('{"a":1}')).toEqual({ a: 1 });
+  });
+
+  it('leaves non-JSON strings as raw strings', () => {
+    expect(parseFlagValue('net.minecraft.world.entity.Entity')).toBe(
+      'net.minecraft.world.entity.Entity',
+    );
+    expect(parseFlagValue('yarn')).toBe('yarn');
+  });
+});
+
+describe('parseArgs', () => {
+  it('returns the tool name with no params when only the tool is given', () => {
+    expect(parseArgs([TOOL])).toEqual({ tool: TOOL, params: {} });
+  });
+
+  it('parses --key value flags', () => {
+    const { tool, params } = parseArgs([TOOL, '--version', '1.21.10', '--mapping', 'yarn']);
+    expect(tool).toBe(TOOL);
+    expect(params).toEqual({ version: '1.21.10', mapping: 'yarn' });
+  });
+
+  it('parses --key=value flags', () => {
+    const { params } = parseArgs([TOOL, '--version=1.21.10', '--mapping=mojmap']);
+    expect(params).toEqual({ version: '1.21.10', mapping: 'mojmap' });
+  });
+
+  it('treats a bare trailing flag as true', () => {
+    const { params } = parseArgs([TOOL, '--force']);
+    expect(params).toEqual({ force: true });
+  });
+
+  it('coerces flag values via parseFlagValue', () => {
+    const { params } = parseArgs([TOOL, '--limit', '50', '--includeAllClasses', 'true']);
+    expect(params).toEqual({ limit: 50, includeAllClasses: true });
+  });
+
+  it('does not consume a following flag as a value', () => {
+    const { params } = parseArgs([TOOL, '--force', '--version', '1.21.10']);
+    expect(params).toEqual({ force: true, version: '1.21.10' });
+  });
+});

--- a/__tests__/tools/cli-args.test.ts
+++ b/__tests__/tools/cli-args.test.ts
@@ -1,27 +1,45 @@
-import { describe, expect, it } from 'vitest';
-import { parseArgs, parseFlagValue } from '../../src/cli.js';
+import { describe, expect, it, vi } from 'vitest';
+import { coerceFlagValue, parseArgs } from '../../src/cli.js';
 import { tools } from '../../src/server/tools.js';
 
 // A stable, known tool name to drive parseArgs tests.
 const TOOL = tools[0].name;
 
-describe('parseFlagValue', () => {
-  it('coerces booleans', () => {
-    expect(parseFlagValue('true')).toBe(true);
-    expect(parseFlagValue('false')).toBe(false);
-  });
-
-  it('coerces JSON literals', () => {
-    expect(parseFlagValue('42')).toBe(42);
-    expect(parseFlagValue('[1,2,3]')).toEqual([1, 2, 3]);
-    expect(parseFlagValue('{"a":1}')).toEqual({ a: 1 });
-  });
-
-  it('leaves non-JSON strings as raw strings', () => {
-    expect(parseFlagValue('net.minecraft.world.entity.Entity')).toBe(
+describe('coerceFlagValue', () => {
+  it('keeps string-typed values as raw strings (no JSON guessing)', () => {
+    // Regression: "1.20" must not become the number 1.2, "42" must stay "42".
+    expect(coerceFlagValue('1.20', 'string')).toBe('1.20');
+    expect(coerceFlagValue('26', 'string')).toBe('26');
+    expect(coerceFlagValue('true', 'string')).toBe('true');
+    expect(coerceFlagValue('net.minecraft.world.entity.Entity', 'string')).toBe(
       'net.minecraft.world.entity.Entity',
     );
-    expect(parseFlagValue('yarn')).toBe('yarn');
+  });
+
+  it('defaults to raw string when the type is unknown', () => {
+    expect(coerceFlagValue('1.20')).toBe('1.20');
+    expect(coerceFlagValue('hello')).toBe('hello');
+  });
+
+  it('coerces number / integer types', () => {
+    expect(coerceFlagValue('50', 'number')).toBe(50);
+    expect(coerceFlagValue('3', 'integer')).toBe(3);
+    // Non-numeric value for a number field falls back to the raw string.
+    expect(coerceFlagValue('abc', 'number')).toBe('abc');
+  });
+
+  it('coerces boolean types', () => {
+    expect(coerceFlagValue('true', 'boolean')).toBe(true);
+    expect(coerceFlagValue('1', 'boolean')).toBe(true);
+    expect(coerceFlagValue('false', 'boolean')).toBe(false);
+    expect(coerceFlagValue('0', 'boolean')).toBe(false);
+  });
+
+  it('parses array / object types as JSON', () => {
+    expect(coerceFlagValue('[1,2,3]', 'array')).toEqual([1, 2, 3]);
+    expect(coerceFlagValue('{"a":1}', 'object')).toEqual({ a: 1 });
+    // Invalid JSON falls back to the raw string.
+    expect(coerceFlagValue('not json', 'array')).toBe('not json');
   });
 });
 
@@ -30,10 +48,10 @@ describe('parseArgs', () => {
     expect(parseArgs([TOOL])).toEqual({ tool: TOOL, params: {} });
   });
 
-  it('parses --key value flags', () => {
-    const { tool, params } = parseArgs([TOOL, '--version', '1.21.10', '--mapping', 'yarn']);
-    expect(tool).toBe(TOOL);
-    expect(params).toEqual({ version: '1.21.10', mapping: 'yarn' });
+  it('keeps string-typed flags as strings (schema-driven)', () => {
+    // get_minecraft_source.version is type "string" in the schema.
+    const { params } = parseArgs([TOOL, '--version', '1.20', '--mapping', 'yarn']);
+    expect(params).toEqual({ version: '1.20', mapping: 'yarn' });
   });
 
   it('parses --key=value flags', () => {
@@ -41,18 +59,42 @@ describe('parseArgs', () => {
     expect(params).toEqual({ version: '1.21.10', mapping: 'mojmap' });
   });
 
-  it('treats a bare trailing flag as true', () => {
-    const { params } = parseArgs([TOOL, '--force']);
-    expect(params).toEqual({ force: true });
+  it('coerces number-typed flags via the schema', () => {
+    // startLine / maxLines are type "number".
+    const { params } = parseArgs([
+      TOOL,
+      '--version',
+      '1.21.10',
+      '--startLine',
+      '10',
+      '--maxLines',
+      '200',
+    ]);
+    expect(params).toMatchObject({ startLine: 10, maxLines: 200 });
   });
 
-  it('coerces flag values via parseFlagValue', () => {
-    const { params } = parseArgs([TOOL, '--limit', '50', '--includeAllClasses', 'true']);
-    expect(params).toEqual({ limit: 50, includeAllClasses: true });
+  it('treats a bare trailing flag as true', () => {
+    const { params } = parseArgs([TOOL, '--version', '1.21.10', '--someFlag']);
+    expect(params.someFlag).toBe(true);
   });
 
   it('does not consume a following flag as a value', () => {
-    const { params } = parseArgs([TOOL, '--force', '--version', '1.21.10']);
-    expect(params).toEqual({ force: true, version: '1.21.10' });
+    const { params } = parseArgs([TOOL, '--someFlag', '--version', '1.21.10']);
+    expect(params).toEqual({ someFlag: true, version: '1.21.10' });
+  });
+
+  it('rejects a bare -- flag with an empty key', () => {
+    // parseArgs calls process.exit on error; assert it throws/exits rather than
+    // silently producing an empty-string key.
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`exit:${code}`);
+    }) as never);
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      expect(() => parseArgs([TOOL, '--'])).toThrow('exit:1');
+    } finally {
+      exitSpy.mockRestore();
+      errSpy.mockRestore();
+    }
   });
 });

--- a/__tests__/tools/cli.e2e.test.ts
+++ b/__tests__/tools/cli.e2e.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { runCli } from '../helpers/cli-runner.js';
+
+/**
+ * CLI process-level E2E tests.
+ *
+ * These spawn the actual CLI entrypoint and assert on its stdout/stderr/exit code.
+ * They intentionally cover only the paths that need neither Java nor network
+ * (help, list-tools, argument errors) so they stay fast and run in the default suite.
+ */
+describe('minecraft-dev CLI (process E2E)', () => {
+  it('prints help and exits 0 with no arguments', async () => {
+    const { exitCode, stdout } = await runCli([]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('Minecraft Dev CLI');
+    expect(stdout).toContain('USAGE:');
+  });
+
+  it('prints help for the help command', async () => {
+    const { exitCode, stdout } = await runCli(['help']);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('AVAILABLE TOOLS:');
+  });
+
+  it('lists all tools as valid JSON', async () => {
+    const { exitCode, stdout } = await runCli(['list-tools']);
+    expect(exitCode).toBe(0);
+
+    const parsed = JSON.parse(stdout);
+    expect(parsed.total).toBe(20);
+    expect(Array.isArray(parsed.tools)).toBe(true);
+    expect(parsed.tools).toHaveLength(20);
+
+    const names = parsed.tools.map((t: { name: string }) => t.name);
+    expect(names).toContain('get_minecraft_source');
+    expect(names).toContain('decompile_minecraft_version');
+
+    // Every tool entry exposes its parameter schema.
+    for (const tool of parsed.tools) {
+      expect(tool).toHaveProperty('name');
+      expect(tool).toHaveProperty('description');
+      expect(tool).toHaveProperty('parameters');
+    }
+  });
+
+  it('errors with exit 1 and JSON for an unknown tool', async () => {
+    const { exitCode, stderr } = await runCli(['not_a_real_tool']);
+    expect(exitCode).toBe(1);
+
+    const parsed = JSON.parse(stderr);
+    expect(parsed.error).toContain('Unknown tool: not_a_real_tool');
+  });
+
+  it('rejects positional arguments after a valid tool', async () => {
+    const { exitCode, stderr } = await runCli(['get_minecraft_source', 'oops']);
+    expect(exitCode).toBe(1);
+
+    const parsed = JSON.parse(stderr);
+    expect(parsed.error).toContain('Unexpected positional argument: oops');
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,26 +1,29 @@
 {
   "name": "@mcdxai/minecraft-dev-mcp",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcdxai/minecraft-dev-mcp",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.0.4",
+        "@modelcontextprotocol/sdk": "^1.24.0",
         "adm-zip": "^0.5.16",
         "better-sqlite3": "^11.7.0",
+        "express": "^5.0.1",
         "zod": "^3.24.1"
       },
       "bin": {
+        "minecraft-dev-cli": "dist/cli.js",
         "minecraft-dev-mcp": "dist/index.js"
       },
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
         "@types/adm-zip": "^0.5.5",
         "@types/better-sqlite3": "^7.6.12",
+        "@types/express": "^5.0.6",
         "@types/node": "^22.10.1",
         "cross-env": "^7.0.3",
         "rimraf": "^6.0.1",
@@ -1033,10 +1036,63 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/express": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+      "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "^2"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
+      "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1048,6 +1104,41 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*"
       }
     },
     "node_modules/@vitest/expect": {

--- a/package.json
+++ b/package.json
@@ -1,15 +1,22 @@
 {
   "name": "@mcdxai/minecraft-dev-mcp",
   "version": "1.1.0",
-  "description": "MCP server for Minecraft mod development - decompile, remap, and explore Minecraft source code",
+  "description": "MCP server and CLI for Minecraft mod development - decompile, remap, and explore Minecraft source code",
   "type": "module",
   "main": "./dist/index.js",
   "bin": {
-    "minecraft-dev-mcp": "./dist/index.js"
+    "minecraft-dev-mcp": "./dist/index.js",
+    "minecraft-dev-cli": "./dist/cli.js"
   },
-  "files": ["dist", "README.md", "LICENSE"],
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
   "scripts": {
+    "cli": "tsx src/cli.ts",
     "dev": "tsx watch src/index.ts",
+    "dev:http": "tsx watch src/index.ts --http",
     "build": "tsc",
     "prepublishOnly": "npm run clean && npm run build",
     "inspect": "npm run build && npx @modelcontextprotocol/inspector node dist/index.js",
@@ -34,7 +41,14 @@
     "lint:fix": "biome check --write .",
     "clean": "rimraf dist"
   },
-  "keywords": ["minecraft", "fabric", "mod-development", "mcp", "decompiler", "mappings"],
+  "keywords": [
+    "minecraft",
+    "fabric",
+    "mod-development",
+    "mcp",
+    "decompiler",
+    "mappings"
+  ],
   "author": "GhostTypes",
   "license": "MIT",
   "repository": {
@@ -46,15 +60,17 @@
   },
   "homepage": "https://github.com/MCDxAI/minecraft-dev-mcp#readme",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.0.4",
+    "@modelcontextprotocol/sdk": "^1.24.0",
     "adm-zip": "^0.5.16",
     "better-sqlite3": "^11.7.0",
+    "express": "^5.0.1",
     "zod": "^3.24.1"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
     "@types/adm-zip": "^0.5.5",
     "@types/better-sqlite3": "^7.6.12",
+    "@types/express": "^5.0.6",
     "@types/node": "^22.10.1",
     "cross-env": "^7.0.3",
     "rimraf": "^6.0.1",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,230 @@
+#!/usr/bin/env node
+
+/**
+ * Minecraft Dev CLI
+ * Command-line interface for invoking MCP tools directly without the MCP protocol.
+ * Designed for use in scripts, skills, and automation.
+ *
+ * Arguments are flags-only (`--key value` or `--key=value`) to avoid the JSON
+ * quoting pain that positional JSON arguments cause in PowerShell and other shells.
+ */
+
+import { fileURLToPath } from 'node:url';
+import { verifyJavaVersion } from './java/java-process.js';
+import { handleToolCall, tools } from './server/tools.js';
+import { logger } from './utils/logger.js';
+
+// CLI output helper - always emits to stdout, never breaks structured output
+function output(data: unknown): void {
+  console.log(JSON.stringify(data, null, 2));
+}
+
+function outputError(message: string): never {
+  console.error(JSON.stringify({ error: message }, null, 2));
+  process.exit(1);
+}
+
+/**
+ * Coerce a flag value: booleans and JSON literals (numbers, arrays, objects)
+ * are parsed; everything else is left as a raw string.
+ */
+export function parseFlagValue(value: string): unknown {
+  if (value === 'true') return true;
+  if (value === 'false') return false;
+
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+// Print help text
+function printHelp(): void {
+  const helpText = `
+Minecraft Dev CLI - Command-line interface for Minecraft mod development tools
+
+USAGE:
+  minecraft-dev-cli <command> [--key value ...]
+
+COMMANDS:
+  list-tools           List all available tools with their parameters
+  help                 Show this help message
+  <tool-name>          Invoke a tool with flags
+
+EXAMPLES:
+  # List all available tools
+  minecraft-dev-cli list-tools
+
+  # Get Minecraft source for a class
+  minecraft-dev-cli get_minecraft_source --version 1.21.10 --className net.minecraft.world.entity.Entity --mapping yarn
+
+  # List available Minecraft versions
+  minecraft-dev-cli list_minecraft_versions
+
+  # Analyze a mod JAR
+  minecraft-dev-cli analyze_mod_jar --jarPath /path/to/mod.jar
+
+  # Search Minecraft code
+  minecraft-dev-cli search_minecraft_code --version 1.21.10 --query Entity --searchType class --mapping yarn
+
+AVAILABLE TOOLS:
+${tools.map((t) => `  ${t.name.padEnd(35)} ${t.description.split('.')[0]}`).join('\n')}
+
+For full parameter details on every tool, run: minecraft-dev-cli list-tools
+
+ENVIRONMENT VARIABLES:
+  CACHE_DIR   Override the default cache directory location
+  LOG_LEVEL   Logging verbosity: DEBUG, INFO, WARN, ERROR
+
+SKILL INTEGRATION:
+  This CLI is designed to be called from skills and scripts:
+  - Output is always valid JSON
+  - Exit code 0 for success, 1 for error
+  - Tool results are in the "result" field of the response
+`.trim();
+
+  console.log(helpText);
+}
+
+// List all tools with their schemas
+function listTools(): void {
+  const toolList = tools.map((t) => ({
+    name: t.name,
+    description: t.description,
+    parameters: t.inputSchema,
+  }));
+
+  output({
+    tools: toolList,
+    total: tools.length,
+  });
+}
+
+export interface ParsedArgs {
+  tool: string;
+  params: Record<string, unknown>;
+}
+
+/**
+ * Parse arguments - flags only: tool-name --key value --key2 value2 (or --key=value).
+ * A bare trailing flag (no following value) is treated as `true`.
+ */
+export function parseArgs(args: string[]): ParsedArgs {
+  if (args.length === 0) {
+    outputError('No command specified. Run "minecraft-dev-cli help" for usage.');
+  }
+
+  const command = args[0];
+
+  // Find the tool
+  const tool = tools.find((t) => t.name === command);
+  if (!tool) {
+    outputError(
+      `Unknown tool: ${command}\nRun "minecraft-dev-cli list-tools" to see available tools.`,
+    );
+  }
+
+  // Parse parameters
+  const params: Record<string, unknown> = {};
+
+  for (let i = 1; i < args.length; i++) {
+    const arg = args[i];
+    if (!arg.startsWith('--')) {
+      outputError(`Unexpected positional argument: ${arg}\nUse --key value or --key=value flags.`);
+    }
+
+    const eqIndex = arg.indexOf('=');
+    if (eqIndex > 2) {
+      const key = arg.slice(2, eqIndex);
+      const value = arg.slice(eqIndex + 1);
+      params[key] = parseFlagValue(value);
+      continue;
+    }
+
+    const key = arg.slice(2);
+    const nextArg = args[i + 1];
+    if (nextArg && !nextArg.startsWith('--')) {
+      params[key] = parseFlagValue(nextArg);
+      i++;
+    } else {
+      params[key] = true;
+    }
+  }
+
+  return { tool: tool.name, params };
+}
+
+// Invoke a tool and format output
+async function invokeTool(toolName: string, params: Record<string, unknown>): Promise<void> {
+  // Most tools shell out to Java; verify it here rather than for help/list-tools.
+  try {
+    await verifyJavaVersion(17);
+  } catch (error) {
+    outputError(
+      `Java 17+ is required but not found: ${error instanceof Error ? error.message : 'Unknown error'}`,
+    );
+  }
+
+  try {
+    logger.info(`Invoking tool: ${toolName} with params: ${JSON.stringify(params)}`);
+
+    const result = await handleToolCall(toolName, params);
+
+    if (result.isError) {
+      const errorText =
+        result.content?.[0]?.type === 'text' ? result.content[0].text : 'Unknown error';
+
+      output({ success: false, tool: toolName, error: errorText });
+      process.exit(1);
+    }
+
+    // Unwrap and parse the text content if it is JSON
+    let parsedResult: unknown = result;
+    if (result.content?.[0]?.type === 'text') {
+      try {
+        parsedResult = JSON.parse(result.content[0].text);
+      } catch {
+        parsedResult = result.content[0].text;
+      }
+    }
+
+    output({ success: true, tool: toolName, result: parsedResult });
+  } catch (error) {
+    logger.error(`Tool invocation failed: ${toolName}`, error);
+    output({
+      success: false,
+      tool: toolName,
+      error: error instanceof Error ? error.message : 'Unknown error',
+    });
+    process.exit(1);
+  }
+}
+
+// Main entry point
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+
+  const command = args[0];
+
+  if (!command || command === 'help' || command === '--help' || command === '-h') {
+    printHelp();
+    process.exit(0);
+  }
+
+  if (command === 'list-tools') {
+    listTools();
+    process.exit(0);
+  }
+
+  const { tool, params } = parseArgs(args);
+  await invokeTool(tool, params);
+}
+
+// Run only when executed directly (not when imported by tests)
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+if (isMain) {
+  main().catch((error) => {
+    outputError(`CLI failed: ${error instanceof Error ? error.message : 'Unknown error'}`);
+  });
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,17 +25,32 @@ function outputError(message: string): never {
 }
 
 /**
- * Coerce a flag value: booleans and JSON literals (numbers, arrays, objects)
- * are parsed; everything else is left as a raw string.
+ * Coerce a flag value based on the parameter's JSON-schema type.
+ *
+ * Coercion is schema-driven (not value-guessing) so that string fields keep
+ * their literal text: `--version 1.20` stays "1.20" rather than becoming the
+ * number 1.2, and `--query 42` stays "42". Only number/boolean/array/object
+ * fields are converted.
  */
-export function parseFlagValue(value: string): unknown {
-  if (value === 'true') return true;
-  if (value === 'false') return false;
-
-  try {
-    return JSON.parse(value);
-  } catch {
-    return value;
+export function coerceFlagValue(value: string, expectedType?: string): unknown {
+  switch (expectedType) {
+    case 'number':
+    case 'integer': {
+      const num = Number(value);
+      return Number.isNaN(num) ? value : num;
+    }
+    case 'boolean':
+      return value === 'true' || value === '1';
+    case 'array':
+    case 'object':
+      try {
+        return JSON.parse(value);
+      } catch {
+        return value;
+      }
+    default:
+      // string or unknown type -> keep the raw string
+      return value;
   }
 }
 
@@ -125,6 +140,12 @@ export function parseArgs(args: string[]): ParsedArgs {
     );
   }
 
+  const properties = (
+    tool.inputSchema as unknown as {
+      properties?: Record<string, { type?: string } | undefined>;
+    }
+  ).properties;
+
   // Parse parameters
   const params: Record<string, unknown> = {};
 
@@ -134,21 +155,31 @@ export function parseArgs(args: string[]): ParsedArgs {
       outputError(`Unexpected positional argument: ${arg}\nUse --key value or --key=value flags.`);
     }
 
+    let key: string;
+    let value: string | undefined;
+
     const eqIndex = arg.indexOf('=');
     if (eqIndex > 2) {
-      const key = arg.slice(2, eqIndex);
-      const value = arg.slice(eqIndex + 1);
-      params[key] = parseFlagValue(value);
-      continue;
+      key = arg.slice(2, eqIndex);
+      value = arg.slice(eqIndex + 1);
+    } else {
+      key = arg.slice(2);
+      const nextArg = args[i + 1];
+      if (nextArg && !nextArg.startsWith('--')) {
+        value = nextArg;
+        i++;
+      }
     }
 
-    const key = arg.slice(2);
-    const nextArg = args[i + 1];
-    if (nextArg && !nextArg.startsWith('--')) {
-      params[key] = parseFlagValue(nextArg);
-      i++;
-    } else {
+    if (!key) {
+      outputError(`Invalid flag: ${arg}\nUse --key value or --key=value flags.`);
+    }
+
+    if (value === undefined) {
+      // Bare flag (no value) -> boolean true
       params[key] = true;
+    } else {
+      params[key] = coerceFlagValue(value, properties?.[key]?.type);
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,30 @@ function parseTransportOptions(args: string[]): TransportOptions {
   return { mode, host, port };
 }
 
+/**
+ * Resolve the MCP session id from the `mcp-session-id` header, falling back to
+ * a `?sessionId=` query parameter for browser clients that use the native
+ * EventSource API (which cannot set custom headers).
+ *
+ * When the id comes from the query, it is copied into the request header so the
+ * SDK transport's internal session validation (which only reads the header)
+ * accepts it.
+ */
+function resolveSessionId(req: ExpressRequest): string | undefined {
+  const header = req.headers['mcp-session-id'];
+  if (typeof header === 'string') {
+    return header;
+  }
+
+  const query = req.query.sessionId;
+  if (typeof query === 'string' && query.length > 0) {
+    req.headers['mcp-session-id'] = query;
+    return query;
+  }
+
+  return undefined;
+}
+
 class MinecraftDevMCPServer {
   constructor() {
     this.setupErrorHandling();
@@ -211,7 +235,7 @@ class MinecraftDevMCPServer {
 
     app.post('/mcp', async (req, res) => {
       try {
-        const sessionId = req.headers['mcp-session-id'] as string | undefined;
+        const sessionId = resolveSessionId(req);
         let transport = sessionId ? transports[sessionId] : undefined;
 
         if (!transport && isInitializeRequest(req.body)) {
@@ -256,7 +280,7 @@ class MinecraftDevMCPServer {
 
     // GET (SSE stream) and DELETE (session teardown) reuse the session transport.
     const handleSessionRequest = async (req: ExpressRequest, res: ExpressResponse) => {
-      const sessionId = req.headers['mcp-session-id'] as string | undefined;
+      const sessionId = resolveSessionId(req);
       const transport = sessionId ? transports[sessionId] : undefined;
       if (!transport) {
         res.status(400).send('Invalid or missing session ID');

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,19 @@
 #!/usr/bin/env node
 
+import crypto from 'node:crypto';
+import { createMcpExpressApp } from '@modelcontextprotocol/sdk/server/express.js';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import {
   CallToolRequestSchema,
   ListResourceTemplatesRequestSchema,
   ListResourcesRequestSchema,
   ListToolsRequestSchema,
   ReadResourceRequestSchema,
+  isInitializeRequest,
 } from '@modelcontextprotocol/sdk/types.js';
+import type { Request as ExpressRequest, Response as ExpressResponse } from 'express';
 import { closeDatabase } from './cache/database.js';
 import { verifyJavaVersion } from './java/java-process.js';
 import { handleReadResource, resourceTemplates, resources } from './server/resources.js';
@@ -20,11 +25,52 @@ import { logger } from './utils/logger.js';
  * Provides decompiled Minecraft source code access for LLM-assisted mod development
  */
 
-class MinecraftDevMCPServer {
-  private server: Server;
+const DEFAULT_HTTP_PORT = 3000;
+// Default to loopback so the SDK enables DNS-rebinding protection automatically.
+// Bind to 0.0.0.0 only when explicitly requested via --host.
+const DEFAULT_HTTP_HOST = '127.0.0.1';
 
+interface TransportOptions {
+  mode: 'stdio' | 'http';
+  host: string;
+  port: number;
+}
+
+/**
+ * Parse transport selection from CLI args.
+ * `--http` or `--port <n>` selects HTTP; otherwise stdio.
+ */
+function parseTransportOptions(args: string[]): TransportOptions {
+  const portIndex = args.indexOf('--port');
+  const hasPort = portIndex !== -1 && args[portIndex + 1] !== undefined;
+  const mode = hasPort || args.includes('--http') ? 'http' : 'stdio';
+
+  let port = DEFAULT_HTTP_PORT;
+  if (hasPort) {
+    const parsed = Number.parseInt(args[portIndex + 1], 10);
+    if (!Number.isNaN(parsed)) {
+      port = parsed;
+    }
+  }
+
+  const hostIndex = args.indexOf('--host');
+  const host =
+    hostIndex !== -1 && args[hostIndex + 1] !== undefined ? args[hostIndex + 1] : DEFAULT_HTTP_HOST;
+
+  return { mode, host, port };
+}
+
+class MinecraftDevMCPServer {
   constructor() {
-    this.server = new Server(
+    this.setupErrorHandling();
+  }
+
+  /**
+   * Build a fresh MCP Server with all request handlers attached.
+   * A new instance is created per stdio process and per HTTP session.
+   */
+  private createServer(): Server {
+    const server = new Server(
       {
         name: 'minecraft-dev-mcp',
         version: '1.0.0',
@@ -37,19 +83,18 @@ class MinecraftDevMCPServer {
       },
     );
 
-    this.setupHandlers();
-    this.setupErrorHandling();
-  }
+    server.onerror = (error) => {
+      logger.error('Server error', error);
+    };
 
-  private setupHandlers(): void {
     // List available tools
-    this.server.setRequestHandler(ListToolsRequestSchema, async () => {
+    server.setRequestHandler(ListToolsRequestSchema, async () => {
       logger.debug('Listing tools');
       return { tools };
     });
 
     // Handle tool calls
-    this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    server.setRequestHandler(CallToolRequestSchema, async (request) => {
       logger.info(`Tool called: ${request.params.name}`);
 
       try {
@@ -70,19 +115,19 @@ class MinecraftDevMCPServer {
     });
 
     // List available resources
-    this.server.setRequestHandler(ListResourcesRequestSchema, async () => {
+    server.setRequestHandler(ListResourcesRequestSchema, async () => {
       logger.debug('Listing resources');
       return { resources };
     });
 
     // List resource templates
-    this.server.setRequestHandler(ListResourceTemplatesRequestSchema, async () => {
+    server.setRequestHandler(ListResourceTemplatesRequestSchema, async () => {
       logger.debug('Listing resource templates');
       return { resourceTemplates };
     });
 
     // Handle resource reads
-    this.server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
+    server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
       logger.info(`Reading resource: ${request.params.uri}`);
 
       try {
@@ -93,14 +138,11 @@ class MinecraftDevMCPServer {
         throw error;
       }
     });
+
+    return server;
   }
 
   private setupErrorHandling(): void {
-    // Handle server errors
-    this.server.onerror = (error) => {
-      logger.error('Server error', error);
-    };
-
     // Handle process errors
     process.on('uncaughtException', (error) => {
       logger.error('Uncaught exception', error);
@@ -142,12 +184,94 @@ class MinecraftDevMCPServer {
       process.exit(1);
     }
 
-    // Start server with stdio transport
-    const transport = new StdioServerTransport();
-    await this.server.connect(transport);
+    const options = parseTransportOptions(process.argv.slice(2));
 
-    logger.info('Minecraft Dev MCP Server started');
+    if (options.mode === 'http') {
+      await this.startHttp(options.host, options.port);
+    } else {
+      await this.startStdio();
+    }
+  }
+
+  private async startStdio(): Promise<void> {
+    const transport = new StdioServerTransport();
+    await this.createServer().connect(transport);
+
+    logger.info('Minecraft Dev MCP Server started on stdio');
     logger.info('Server is ready to accept requests');
+  }
+
+  private async startHttp(host: string, port: number): Promise<void> {
+    // createMcpExpressApp wires express.json() and, for localhost hosts,
+    // DNS-rebinding protection. Binding to non-localhost hosts is opt-in.
+    const app = createMcpExpressApp({ host });
+
+    // One transport per active session, keyed by the MCP session id.
+    const transports: Record<string, StreamableHTTPServerTransport> = {};
+
+    app.post('/mcp', async (req, res) => {
+      try {
+        const sessionId = req.headers['mcp-session-id'] as string | undefined;
+        let transport = sessionId ? transports[sessionId] : undefined;
+
+        if (!transport && isInitializeRequest(req.body)) {
+          // New session: create a transport + server and register on init.
+          transport = new StreamableHTTPServerTransport({
+            sessionIdGenerator: () => crypto.randomUUID(),
+            onsessioninitialized: (id) => {
+              transports[id] = transport as StreamableHTTPServerTransport;
+              logger.info(`HTTP session initialized: ${id}`);
+            },
+          });
+
+          transport.onclose = () => {
+            if (transport?.sessionId) {
+              delete transports[transport.sessionId];
+              logger.info(`HTTP session closed: ${transport.sessionId}`);
+            }
+          };
+
+          await this.createServer().connect(transport);
+        } else if (!transport) {
+          res.status(400).json({
+            jsonrpc: '2.0',
+            error: { code: -32000, message: 'Bad Request: No valid session ID provided' },
+            id: null,
+          });
+          return;
+        }
+
+        await transport.handleRequest(req, res, req.body);
+      } catch (error) {
+        logger.error('Error handling HTTP request', error);
+        if (!res.headersSent) {
+          res.status(500).json({
+            jsonrpc: '2.0',
+            error: { code: -32603, message: 'Internal Server Error' },
+            id: null,
+          });
+        }
+      }
+    });
+
+    // GET (SSE stream) and DELETE (session teardown) reuse the session transport.
+    const handleSessionRequest = async (req: ExpressRequest, res: ExpressResponse) => {
+      const sessionId = req.headers['mcp-session-id'] as string | undefined;
+      const transport = sessionId ? transports[sessionId] : undefined;
+      if (!transport) {
+        res.status(400).send('Invalid or missing session ID');
+        return;
+      }
+      await transport.handleRequest(req, res);
+    };
+
+    app.get('/mcp', handleSessionRequest);
+    app.delete('/mcp', handleSessionRequest);
+
+    app.listen(port, host, () => {
+      logger.info(`Minecraft Dev MCP Server started with HTTP transport on ${host}:${port}`);
+      logger.info(`Endpoint: http://${host}:${port}/mcp`);
+    });
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -286,7 +286,14 @@ class MinecraftDevMCPServer {
         res.status(400).send('Invalid or missing session ID');
         return;
       }
-      await transport.handleRequest(req, res);
+      try {
+        await transport.handleRequest(req, res);
+      } catch (error) {
+        logger.error('Error handling HTTP session request', error);
+        if (!res.headersSent) {
+          res.status(500).send('Internal Server Error');
+        }
+      }
     };
 
     app.get('/mcp', handleSessionRequest);


### PR DESCRIPTION
## Summary

Backports two genuinely useful features from the [klikli-dev fork](https://github.com/klikli-dev/minecraft-dev-mcp) — reimplemented and corrected for our repo. (The fork's skill, package rename, README de-centering, and bun lockfile were deliberately skipped.)

### 1. HTTP (Streamable) transport
Run the server over HTTP for clients/editors that can't use stdio:

```bash
minecraft-dev-mcp --http --port 3000   # endpoint: http://127.0.0.1:3000/mcp
```

- **Per-session transport map** (created on `initialize`, torn down on close) — genuinely supports concurrent clients. The fork shared a single transport across all requests; this does not.
- **Secure default**: binds `127.0.0.1`, so the SDK's DNS-rebinding protection turns on automatically. `--host 0.0.0.0` is opt-in (the fork defaulted to `0.0.0.0`).
- Server construction refactored into a per-session `createServer()` factory shared by stdio and HTTP.

### 2. Standalone CLI (`minecraft-dev-cli`)
Invokes the existing tools directly — no MCP client — for scripts, skills, and automation:

```bash
minecraft-dev-cli list-tools
minecraft-dev-cli get_minecraft_source --version 1.21.10 --className net.minecraft.world.entity.Entity --mapping yarn
```

- **Flags-only** (`--key value` / `--key=value`) to avoid the JSON-quoting pain positional JSON arguments cause in PowerShell and other shells.
- Java is verified only for real tool calls, so `help` / `list-tools` work without a JDK (fork required Java for everything).
- Reuses our existing `tools` + `handleToolCall` exports — no tool-layer changes.

### Supporting changes
- Deps: `express` + `@types/express`; raised `@modelcontextprotocol/sdk` floor to `^1.24.0` (required by `createMcpExpressApp`).
- Scripts: `cli`, `dev:http`. New bin: `minecraft-dev-cli`.
- README: documents both features, keeping the existing centered formatting.

## Testing

| Suite | Result |
|---|---|
| `npm test` (default suite) | **24 files / 234 tests passed** |
| HTTP transport E2E (manual) | **5/5 passed** |
| typecheck / build / biome lint | clean |

New coverage:
- `__tests__/tools/cli-args.test.ts` — flag-parsing unit tests
- `__tests__/tools/cli.e2e.test.ts` — CLI process E2E (help, list-tools, unknown-tool, positional-arg rejection); no Java/network, runs in CI
- `__tests__/manual/mcp/http-server-smoke.test.ts` — spawns the real `--http` server and drives it via the MCP Streamable HTTP client: tool listing, resource read, concurrent session isolation, bad-request `400`/`-32000`, GET-without-session `400`
- helpers: `cli-runner.ts`, `mcp-http.ts`

The HTTP smoke lives in the manual suite (parity with the existing stdio smoke — spawns the Java-gated server + hits the live Mojang manifest) and is picked up by `npm run test:manual:mcp`.

## Note
Left `version` at `1.1.0` — this is a feature add, so consider bumping to `1.2.0` before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
